### PR TITLE
Update image links to real online photos

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -4,7 +4,7 @@
       <h1 class="text-4xl md:text-6xl font-bold text-primary mb-4 transition-opacity duration-700" data-aos="fade-down">
         pro.mama — курсы для будущих мам
       </h1>
-      <img src="https://placehold.co/400x300" alt="Беременная" class="mx-auto mb-6 rounded-lg shadow" />
+      <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=400&q=80" alt="Беременная" class="mx-auto mb-6 rounded-lg shadow" />
       <p class="text-lg md:text-2xl mb-6 text-gray-700">
         Забота, знание и поддержка на каждом этапе вашей беременности
       </p>

--- a/src/components/TestimonialsSection.vue
+++ b/src/components/TestimonialsSection.vue
@@ -4,17 +4,17 @@
       <h2 class="text-3xl font-semibold text-center text-primary mb-8">Отзывы</h2>
       <div class="grid md:grid-cols-3 gap-6">
         <div class="p-6 bg-secondary/20 rounded-lg text-center">
-          <img src="https://placehold.co/100x100" alt="avatar" class="mx-auto mb-4 rounded-full" />
+          <img src="https://randomuser.me/api/portraits/women/46.jpg" alt="avatar" class="mx-auto mb-4 rounded-full" />
           <p class="italic mb-2">«Эти курсы изменили моё отношение к беременности. Чувствую себя уверенной и спокойной»</p>
           <p class="font-semibold">Анна, Москва</p>
         </div>
         <div class="p-6 bg-secondary/20 rounded-lg text-center">
-          <img src="https://placehold.co/100x100" alt="avatar" class="mx-auto mb-4 rounded-full" />
+          <img src="https://randomuser.me/api/portraits/women/47.jpg" alt="avatar" class="mx-auto mb-4 rounded-full" />
           <p class="italic mb-2">«Благодаря советам специалистов я подготовилась к родам без лишнего волнения»</p>
           <p class="font-semibold">Елена, Санкт-Петербург</p>
         </div>
         <div class="p-6 bg-secondary/20 rounded-lg text-center">
-          <img src="https://placehold.co/100x100" alt="avatar" class="mx-auto mb-4 rounded-full" />
+          <img src="https://randomuser.me/api/portraits/women/48.jpg" alt="avatar" class="mx-auto mb-4 rounded-full" />
           <p class="italic mb-2">«Удобный формат занятий и дружелюбная атмосфера. Рекомендую всем будущим мамам»</p>
           <p class="font-semibold">Мария, Казань</p>
         </div>


### PR DESCRIPTION
## Summary
- swap placeholder hero image with a relevant Unsplash photo
- replace testimonial avatars with RandomUser images

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840a28f7200832385ea687ac69b9dc7