### PR TITLE
Refresh site images and palette

### DIFF
--- a/src/components/CTASection.vue
+++ b/src/components/CTASection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="py-16 bg-gradient-to-r from-pink-50 via-purple-50 to-yellow-50" id="signup">
+  <section class="py-16 bg-gradient-to-r from-secondary via-accent to-white" id="signup">
     <div class="container mx-auto px-4">
       <h2 class="text-3xl font-semibold text-center text-primary mb-8">Записаться на курс</h2>
       <form class="max-w-xl mx-auto grid gap-4" @submit.prevent="submit">
@@ -26,7 +26,7 @@
         />
         <button
           type="submit"
-          class="bg-primary hover:bg-pink-300 text-white font-semibold py-3 px-8 rounded-lg transition-transform duration-300 hover:scale-105"
+          class="bg-primary hover:bg-primary/80 text-white font-semibold py-3 px-8 rounded-lg transition-transform duration-300 hover:scale-105"
         >
           Отправить заявку
         </button>

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -1,29 +1,31 @@
 <template>
   <section
-    class="min-h-screen flex flex-col items-center justify-center text-center bg-gradient-to-b from-pink-100 via-orange-50 to-yellow-100"
+    class="min-h-screen flex items-center bg-gradient-to-b from-pink-50 via-orange-100 to-yellow-50"
     id="hero"
   >
-    <div class="container mx-auto px-4 py-16">
-      <h1
-        class="text-4xl md:text-6xl font-bold font-poppins text-primary mb-4 transition-opacity duration-700"
-        data-aos="fade-down"
-      >
-        pro.mama — курсы для будущих мам
-      </h1>
+    <div class="container mx-auto px-4 py-16 flex flex-col md:flex-row items-center">
+      <div class="md:w-1/2 text-center md:text-left">
+        <h1
+          class="text-4xl md:text-6xl font-bold font-poppins text-primary mb-4 transition-opacity duration-700"
+          data-aos="fade-down"
+        >
+          pro.mama — курсы для будущих мам
+        </h1>
+        <p class="text-lg md:text-2xl mb-6 text-gray-700">
+          Забота, знание и поддержка на каждом этапе вашей беременности
+        </p>
+        <button
+          class="bg-primary hover:bg-primary/80 text-white font-semibold py-3 px-8 rounded-lg transition-transform duration-300 hover:scale-105"
+          @click="$emit('scrollTo', 'signup')"
+        >
+          Записаться на курс
+        </button>
+      </div>
       <img
-        src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=400&q=80"
+        src="https://images.unsplash.com/photo-1457342813143-a1ae27448a82?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080"
         alt="Беременная"
-        class="mx-auto mb-6 rounded-lg shadow-xl"
+        class="w-full md:w-1/2 max-w-md mx-auto rounded-lg shadow-xl mt-8 md:mt-0 md:ml-8"
       />
-      <p class="text-lg md:text-2xl mb-6 text-gray-700">
-        Забота, знание и поддержка на каждом этапе вашей беременности
-      </p>
-      <button
-        class="bg-primary hover:bg-pink-300 text-white font-semibold py-3 px-8 rounded-lg transition-transform duration-300 hover:scale-105"
-        @click="$emit('scrollTo', 'signup')"
-      >
-        Записаться на курс
-      </button>
     </div>
   </section>
 </template>

--- a/src/components/TestimonialsSection.vue
+++ b/src/components/TestimonialsSection.vue
@@ -4,17 +4,17 @@
       <h2 class="text-3xl font-semibold text-center text-primary mb-8">Отзывы</h2>
       <div class="grid md:grid-cols-3 gap-6">
         <div class="p-6 bg-secondary/20 rounded-lg text-center transition-transform hover:-translate-y-1 hover:shadow-lg">
-          <img src="https://randomuser.me/api/portraits/women/46.jpg" alt="avatar" class="mx-auto mb-4 rounded-full" />
+          <img src="https://images.unsplash.com/photo-1557053910-d9eadeed1c58?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400" alt="avatar" class="mx-auto mb-4 rounded-full" />
           <p class="italic mb-2">«Эти курсы изменили моё отношение к беременности. Чувствую себя уверенной и спокойной»</p>
           <p class="font-semibold">Анна, Москва</p>
         </div>
         <div class="p-6 bg-secondary/20 rounded-lg text-center transition-transform hover:-translate-y-1 hover:shadow-lg">
-          <img src="https://randomuser.me/api/portraits/women/47.jpg" alt="avatar" class="mx-auto mb-4 rounded-full" />
+          <img src="https://images.unsplash.com/photo-1580489944761-15a19d654956?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400" alt="avatar" class="mx-auto mb-4 rounded-full" />
           <p class="italic mb-2">«Благодаря советам специалистов я подготовилась к родам без лишнего волнения»</p>
           <p class="font-semibold">Елена, Санкт-Петербург</p>
         </div>
         <div class="p-6 bg-secondary/20 rounded-lg text-center transition-transform hover:-translate-y-1 hover:shadow-lg">
-          <img src="https://randomuser.me/api/portraits/women/48.jpg" alt="avatar" class="mx-auto mb-4 rounded-full" />
+          <img src="https://images.unsplash.com/photo-1614283233556-f35b0c801ef1?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400" alt="avatar" class="mx-auto mb-4 rounded-full" />
           <p class="italic mb-2">«Удобный формат занятий и дружелюбная атмосфера. Рекомендую всем будущим мамам»</p>
           <p class="font-semibold">Мария, Казань</p>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,9 +7,9 @@ module.exports = {
         poppins: ['Poppins', 'sans-serif'],
       },
       colors: {
-        primary: '#F8BBD0',
-        secondary: '#FFECB3',
-        accent: '#BBDEFB',
+        primary: '#FF968A',
+        secondary: '#FFD8A9',
+        accent: '#FFECCE',
       },
     },
   },


### PR DESCRIPTION
## Summary
- use warm pastel colors
- tweak hero layout with responsive design
- update signup gradient
- replace testimonials with Unsplash portraits
- include new hero image

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417f07d6988323aa6e09dde230b26f