### PR TITLE
Simplify startup and polish signup design

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Requires **Node.js 18** or newer.
 
 ```bash
 npm install
-npm run dev
-npm run dev:server # start the API server
+npm run dev:all # start frontend and API together
 ```
 
 The server stores submissions in `server/signups.db` (SQLite) and can send a Telegram notification for each new registration.
@@ -36,10 +35,10 @@ The site will be available on port **3000** and pm2 will restart it automaticall
 npx pm2 stop for-mam
 ```
 
-To run the API server after building:
+To serve the built site and API together:
 
 ```bash
-npm run start:server
+npm start
 ```
 
 ---
@@ -54,8 +53,7 @@ npm run start:server
 
 ```bash
 npm install
-npm run dev
-npm run dev:server # запустить API сервер
+npm run dev:all # запустить фронтенд и сервер вместе
 ```
 
 Сервер сохраняет заявки в `server/signups.db` (SQLite) и может отправлять уведомления в Telegram.
@@ -82,8 +80,8 @@ npm run dev:server # запустить API сервер
 npx pm2 stop for-mam
 ```
 
-Для запуска API сервера после сборки:
+Для запуска собранного сайта и API вместе:
 
 ```bash
-npm run start:server
+npm start
 ```

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,17 @@
+import { spawn } from 'child_process';
+
+const processes = [
+  spawn('npm', ['run', 'dev'], { stdio: 'inherit' }),
+  spawn('npm', ['run', 'dev:server'], { stdio: 'inherit' })
+];
+
+function exitHandler(code) {
+  processes.forEach(p => p.kill('SIGTERM'));
+  if (typeof code === 'number') {
+    process.exit(code);
+  }
+}
+
+processes.forEach(p => p.on('close', exitHandler));
+process.on('SIGINT', () => exitHandler());
+process.on('SIGTERM', () => exitHandler());

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:server": "nodemon server/index.cjs",
+    "dev:all": "node dev.js",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "start": "serve -s dist -l 3000",
-    "start:pm2": "pm2 start npm --name for-mam -- start",
-    "dev:server": "nodemon server/index.cjs",
-    "start:server": "node server/index.cjs"
+    "start": "node server/index.cjs",
+    "start:pm2": "pm2 start npm --name for-mam -- start"
   },
   "dependencies": {
     "better-sqlite3": "^8.7.0",

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -52,7 +52,14 @@ app.post('/api/signup', (req, res) => {
   res.json({ success: true });
 });
 
-const port = process.env.PORT || 3001;
+// Serve built frontend if available
+const distPath = path.join(__dirname, '..', 'dist');
+app.use(express.static(distPath));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
+
+const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Server listening on port ${port}`);
 });

--- a/src/components/CTASection.vue
+++ b/src/components/CTASection.vue
@@ -2,7 +2,10 @@
   <section class="py-16 bg-gradient-to-r from-secondary via-accent to-white" id="signup">
     <div class="container mx-auto px-4">
       <h2 class="text-3xl font-semibold text-center text-primary mb-8">Записаться на курс</h2>
-      <form class="max-w-xl mx-auto grid gap-4" @submit.prevent="submit">
+      <form
+        class="max-w-xl mx-auto grid gap-4 bg-white/80 backdrop-blur p-8 rounded-xl shadow-lg"
+        @submit.prevent="submit"
+      >
         <input
           v-model="name"
           type="text"
@@ -26,13 +29,13 @@
         />
         <button
           type="submit"
-          class="bg-primary hover:bg-primary/80 text-white font-semibold py-3 px-8 rounded-lg transition-transform duration-300 hover:scale-105 animate-pulse"
+          class="bg-primary hover:bg-primary/80 text-white font-semibold py-3 px-8 rounded-lg transition-transform duration-300 hover:scale-105"
         >
           Отправить заявку
         </button>
       </form>
-        <p v-if="success" class="text-green-600 text-center">Спасибо! Мы свяжемся с вами.</p>
-        <p v-if="error" class="text-red-600 text-center">{{ error }}</p>
+        <p v-if="success" class="text-green-600 text-center mt-4">Спасибо! Мы свяжемся с вами.</p>
+        <p v-if="error" class="text-red-600 text-center mt-4">{{ error }}</p>
     </div>
   </section>
 </template>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:3000',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
## Summary
- add `dev.js` helper to launch Vite and API with one command
- serve built frontend from Express and use port 3000 throughout
- restyle signup form with a soft card background

## Testing
- `npm run build`
- `npm start` (terminated after start)


------
https://chatgpt.com/codex/tasks/task_e_688e807df1f8832395f6ae7424d532c4